### PR TITLE
Configure Dependabot grouping for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,21 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      vite:
+        patterns:
+          - 'vite'
+          - 'vite-*'
+          - '@vitejs/*'
+      oxc:
+        patterns:
+          - 'oxlint'
+          - 'oxfmt'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
This PR configures Dependabot to group dependency updates by category, reducing the number of pull requests created during automated dependency updates.

## Key Changes
- **npm packages**: Added grouping configuration to organize updates into two groups:
  - `vite`: Groups Vite and related packages (`vite`, `vite-*`, `@vitejs/*`)
  - `oxc`: Groups Oxc tooling packages (`oxlint`, `oxfmt`)
- **GitHub Actions**: Added grouping configuration to consolidate all GitHub Actions updates into a single group

## Details
These grouping rules will cause Dependabot to batch related dependency updates together, resulting in fewer but more organized pull requests. This improves the review workflow by grouping logically related dependencies while keeping different tool ecosystems separate.

https://claude.ai/code/session_01ULH6tF5eq1u4VW4KKA1UJh