### PR TITLE
Modify release workflow for version bump and permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,3 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-
 name: NPM Publish
 
 on:
@@ -8,22 +5,11 @@ on:
     types: [created]
 
 permissions:
-  id-token: write # required for OIDC
-  contents: read
+  id-token: write # Required for OIDC
+  contents: write # Required for pushing version bump commit
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-      - run: npm ci --ignore-scripts --no-audit --no-fund
-      - run: npm test
-
   publish-npm:
-    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -32,6 +18,16 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: npm install -g npm@latest
-      - run: npm ci --ignore-scripts --no-audit --no-fund
+      - run: npm install --ignore-scripts --no-audit --no-fund
+      - name: Bump version from release tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          npm version $VERSION --no-git-tag-version
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to $VERSION"
+          git push origin HEAD:${{ github.event.repository.default_branch }}
+      - run: npm test
       - run: npm run build
       - run: npm publish --access public


### PR DESCRIPTION
Updated permissions to allow pushing version bump commit and modified the npm install command. Added a step to bump the version based on the release tag.